### PR TITLE
#3 Сделать ручку GET /status

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -16,6 +16,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/backend/src/main/java/ru/eda/tech/Controller.java
+++ b/backend/src/main/java/ru/eda/tech/Controller.java
@@ -1,0 +1,12 @@
+package ru.eda.tech;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+    @GetMapping("/status")
+    public StatusRepresentation getStatusRepresentation(){
+        return new StatusRepresentation(200,"OK","BODY{}");
+    }
+}

--- a/backend/src/main/java/ru/eda/tech/StatusRepresentation.java
+++ b/backend/src/main/java/ru/eda/tech/StatusRepresentation.java
@@ -1,0 +1,23 @@
+package ru.eda.tech;
+
+public class StatusRepresentation {
+    private final int statuscode;
+    private final String reasonphrase;
+    private final String body;
+
+    public StatusRepresentation(int statuscode, String reasonphrase, String body){
+        this.statuscode = statuscode;
+        this.reasonphrase = reasonphrase;
+        this.body = body;
+    }
+
+    public int getStatuscode(){
+        return statuscode;
+    }
+    public String getReasonphrase(){
+        return reasonphrase;
+    }
+    public String getBody(){
+        return body;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+server.port=8090


### PR DESCRIPTION
Поменял порт в application.properties на 8090.
Добавил класс StatusRepresentation, представляющий JSON
{
"statuscode": 200,
"reasonphrase": OK,
"body"; BODY{}
}.
Добавил @RestController, который по @GetMapping("/status") возвращает объект StatusRepresentation.
Не уверен вообще, это то, что надо было сделать по issue или нет?